### PR TITLE
fix(style): fixed not centered text in mobile results

### DIFF
--- a/resources/views/exams/points.blade.php
+++ b/resources/views/exams/points.blade.php
@@ -9,7 +9,7 @@
         <p class="text-xl font-bold uppercase">erradas</p>
     </div>
 
-    <section class="mt-10 flex flex-col items-center justify-center">
+    <section class="mt-10 px-4 flex text-center flex-col items-center justify-center">
         @if(Illuminate\Support\Facades\Session::get('points') > 10)
             <p class="font-semibold text-xl"><span class="text-primary">Parabéns!</span> Passaste no exame! 🎉</p>
             <p class="mt-5">Contudo, tens de saber que o caminho para o sucesso é feito de pequenos avanços e, como tal, não te deves focar
@@ -22,7 +22,7 @@
             <p class="semibold">Continua!</p>
         @endif
 
-        <form class="mt-20" action="{{ route('exams.check', ['slug' => $subject->slug]) }}">
+        <form class="mt-16" action="{{ route('exams.check', ['slug' => $subject->slug]) }}">
             <x-primary-button>Verificar respostas</x-primary-button>
         </form>
     </section>


### PR DESCRIPTION
Fixed the text that was not centered when finishing an exam
Added padding to x axis to add some breathing room in smaller screens

Before:
![image](https://user-images.githubusercontent.com/50304854/211538059-2c3190fa-f03c-4f57-8a5f-409d6a83424d.png)

After:
![image](https://user-images.githubusercontent.com/50304854/211538106-f35f67c8-cf91-42b3-a90a-a5f8c0ee2367.png)
