### PR TITLE
feat(check): added different styling to wrong question numbers

### DIFF
--- a/resources/views/livewire/exams/check.blade.php
+++ b/resources/views/livewire/exams/check.blade.php
@@ -2,41 +2,44 @@
     <div class="w-screen flex items-center md:justify-center space-x-10 overflow-x-scroll md:overflow-auto mt-5 px-5">
         @for ($i = 1; $i <= 10; $i++)
             <div wire:click="change_question({{ $i - 1 }})"
-                class="h-10 w-10 p-5 flex items-center justify-center @if(($current + 1) == $i) bg-primary text-white @else border border-primary text-primary @endif  rounded-full hover:cursor-pointer">
+                class="
+            @if ($this->is_correct_option($answer_questions[$i - 1]->option->order)) bg-primary @else bg-red-700 @endif
+            h-10 w-10 p-5 flex items-center justify-center text-white @if ($current + 1 == $i) brightness-125 @else brightness-110 @endif  rounded-full hover:cursor-pointer">
                 <p>{{ $i }}</p>
             </div>
         @endfor
-</div>
-<section class="mt-5 px-5 md:px-32">
-    <div class="w-full h-48">
-        <img class="object-cover h-full w-full" src="/images/prcmp.jpg" />
     </div>
-
-    <section class="mb-10">
-        <p class="text-lg font-bold mt-5">{{ $current_question->question->question }}</p>
-        <p class="text-sm text-gray-600 mt-2">Tipo de pergunta '{{ $current_question->question->question_type->name }}' do exame
-            '{{ $current_question->question->exam }}'</p>
-        <div class="mt-5 space-y-5">
-            @foreach ($current_question->question->options as $option)
-                <div
-                    class="w-full flex items-center px-5 py-3 border border-gray-100 h-20 rounded transition ease-in-out @if($this->is_correct_option($option->order)) bg-primary text-white @endif">
-                    <p>{{ $option->name }}</p>
-                    @if($this->is_correct_option($option->order))
-                        <x-feathericon-check class="ml-5"></x-feathericon-check>
-                    @elseif($current_question->option->order == $option->order)
-                        <x-feathericon-x class="ml-5"></x-feathericon-x>
-                    @endif
-                </div>
-            @endforeach
+    <section class="mt-5 px-5 md:px-32">
+        <div class="w-full h-48">
+            <img class="object-cover h-full w-full" src="/images/prcmp.jpg" />
         </div>
+
+        <section class="mb-10">
+            <p class="text-lg font-bold mt-5">{{ $current_question->question->question }}</p>
+            <p class="text-sm text-gray-600 mt-2">Tipo de pergunta
+                '{{ $current_question->question->question_type->name }}' do exame
+                '{{ $current_question->question->exam }}'</p>
+            <div class="mt-5 space-y-5">
+                @foreach ($current_question->question->options as $option)
+                    <div
+                        class="w-full flex items-center px-5 py-3 border border-gray-100 h-20 rounded transition ease-in-out @if ($this->is_correct_option($option->order)) bg-primary text-white @endif">
+                        <p>{{ $option->name }}</p>
+                        @if ($this->is_correct_option($option->order))
+                            <x-feathericon-check class="ml-5"></x-feathericon-check>
+                        @elseif($current_question->option->order == $option->order)
+                            <x-feathericon-x class="ml-5"></x-feathericon-x>
+                        @endif
+                    </div>
+                @endforeach
+            </div>
+        </section>
+
+        @if ($current == 9)
+            <div class="w-full flex justify-end">
+                <form action="{{ route('welcome') }}">
+                    <x-primary-button>Terminar</x-primary-button>
+                </form>
+            </div>
+        @endif
     </section>
-
-    @if($current == 9)
-        <div class="w-full flex justify-end">
-            <form action="{{ route('welcome') }}">
-                <x-primary-button>Terminar</x-primary-button>
-            </form>
-        </div>
-    @endif
-</section>
 </div>

--- a/resources/views/livewire/exams/check.blade.php
+++ b/resources/views/livewire/exams/check.blade.php
@@ -3,8 +3,16 @@
         @for ($i = 1; $i <= 10; $i++)
             <div wire:click="change_question({{ $i - 1 }})"
                 class="
-            @if ($this->is_correct_option($answer_questions[$i - 1]->option->order)) bg-primary @else bg-red-700 @endif
-            h-10 w-10 p-5 flex items-center justify-center text-white @if ($current + 1 == $i) brightness-125 @else brightness-110 @endif  rounded-full hover:cursor-pointer">
+            @if ($this->is_correct_option($answer_questions[$i - 1]->option->order)) border border-primary text-primary
+            @if ($current + 1 == $i) bg-gray-200
+             @else bg-white @endif
+@else
+bg-red-600 text-white
+                @if ($current + 1 == $i) bg-red-800
+                @else bg-red-600 @endif
+             @endif
+            h-10 w-10 p-5 flex items-center justify-center
+              rounded-full hover:cursor-pointer">
                 <p>{{ $i }}</p>
             </div>
         @endfor


### PR DESCRIPTION
Added different color to question numbers of wrong question **COLOR PALLETE NEEDS REVIEW**

Before:
![image](https://user-images.githubusercontent.com/50304854/211545368-16f1fb4b-2ea6-4f6e-9a3a-92ef1b001159.png)

After:
![image](https://user-images.githubusercontent.com/50304854/211545432-96c4b4f3-d3ef-4cd4-92c6-dad6ba863795.png)

As said, the color pallete needs to be reviewed, I tried with all the different tailwind reds tones, and none were fitting the application pallete. I also tried using the distinction only in the border much like the current theme but the difference was not visible enough imo