### PR TITLE
fix: use shared auth token resolution for notes view proxy

### DIFF
--- a/src/app/api/backend/[...path]/route.ts
+++ b/src/app/api/backend/[...path]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getToken } from 'next-auth/jwt';
+import { getApiAccessToken } from '@/lib/server-auth';
 import { BASE_URL } from '@/services/api';
 
 export const dynamic = 'force-dynamic';
@@ -9,13 +9,9 @@ async function proxyRequest(
   { params }: { params: Promise<{ path: string[] }> }
 ) {
   const { path } = await params;
-  const token = await getToken({ req: request, secret: process.env.AUTH_SECRET });
-  const accessToken = typeof token?.accessToken === 'string' ? token.accessToken : null;
-  const isExpired =
-    token?.error === 'AccessTokenExpired' ||
-    (typeof token?.accessTokenExpiresAt === 'number' && Date.now() >= token.accessTokenExpiresAt);
+  const accessToken = await getApiAccessToken();
 
-  if (!accessToken || isExpired) {
+  if (!accessToken) {
     return NextResponse.json({ message: 'Authentication required' }, { status: 401 });
   }
 


### PR DESCRIPTION
## Summary

Fixes a bug where clicking "Ver resumo" could fail with:

- `Não foi possível registar a visita ao resumo`

## Root cause

The server-rendered notes page and the `/api/backend` proxy were resolving auth tokens differently.

- The page used the shared `getApiAccessToken()` helper, which supports secure/chunked NextAuth cookies.
- The proxy used `getToken()` directly, which could fail to resolve the same session in some cases.

Because of that mismatch, the proxy could return `401` for `POST /notes/:id/view` even while the page itself loaded correctly.

## Fix

Updated `src/app/api/backend/[...path]/route.ts` to use the shared `getApiAccessToken()` helper instead of calling `getToken()` directly.

This makes client-side proxy requests use the same auth resolution path as server-rendered pages.

## Validation

- Ran `pnpm eslint 'src/app/api/backend/[...path]/route.ts'`

## Expected result

Authenticated users can open note summaries with "Ver resumo" without hitting the visit registration error.
