### PR TITLE
ci: align dev with shared governance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
       day: monday
@@ -15,6 +16,7 @@ updates:
 
   - package-ecosystem: github-actions
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
       day: monday

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [dev, main]
   push:
-    branches: [main]
+    branches: [dev, main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,7 +2,7 @@ name: Security
 
 on:
   pull_request:
-    branches: [main]
+    branches: [dev, main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

Align the `dev` integration branch with the governance/CI setup already used across the public NEI repositories.

- run the existing CI and shared secret-scan jobs for PRs/pushes to `dev` and `main`
- run the shared Dependency Review workflow for PRs to `dev` and `main`
- target routine Dependabot version updates to `dev`
- keep release validation/publishing scoped to `main`
- keep the existing shared CODEOWNERS unchanged

No application runtime code is changed.