### PR TITLE
fix(auth): stop session 401 reload loop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 APP_BASE_URL=https://app.example.com
 NEXT_PUBLIC_BASE_URL=https://api.example.com
+NEXTAUTH_URL=https://app.example.com
 AUTH_SECRET=replace-with-a-random-secret
 AUTH_ISSUER_URL=https://zitadel.example.com
 AUTH_CLIENT_ID=replace-with-zitadel-client-id
@@ -9,3 +10,4 @@ AUTH_POST_LOGOUT_REDIRECT_URI=https://app.example.com
 AUTH_SCOPES=openid email profile offline_access
 # Optional override for the AntiRecurso Project's ZITADEL role claim.
 AUTH_ROLE_CLAIM=urn:zitadel:iam:org:project:roles
+AUTH_DEBUG=false

--- a/README.md
+++ b/README.md
@@ -132,12 +132,13 @@ At minimum, define the variables below before starting the app.
 
 | Variable | Required | Description |
 | --- | --- | --- |
-| `NEXT_PUBLIC_BASE_URL` | Yes | Base URL of the AntiRecurso backend API. This is required by the frontend code but is not currently present in `.env.example`. |
+| `NEXT_PUBLIC_BASE_URL` | Yes | Base URL of the AntiRecurso backend API. |
+| `NEXTAUTH_URL` | Production | Canonical public URL of the deployed AntiRecurso frontend used by NextAuth. |
 | `AUTH_SECRET` | Yes | NextAuth secret used to sign and decrypt session tokens. |
 | `AUTH_ISSUER_URL` | Yes | Zitadel/AuthNEI issuer URL. |
 | `AUTH_CLIENT_ID` | Yes | OAuth client ID for the hosted login flow. |
 | `AUTH_CLIENT_SECRET` | Usually | OAuth client secret for the Zitadel provider. |
-| `AUTH_SCOPES` | No | Defaults to `openid email profile`. |
+| `AUTH_SCOPES` | No | Defaults to `openid email profile offline_access`. Keep `offline_access` enabled when refresh tokens are required. |
 | `AUTH_ROLE_CLAIM` | No | Override for the AntiRecurso Project's ZITADEL role claim. |
 | `AUTH_POST_LOGOUT_REDIRECT_URI` | Recommended | Redirect target after logout. Defaults to `/` if omitted. |
 | `AUTH_DEBUG` | No | Set to `true` to enable verbose auth logging. |
@@ -147,17 +148,20 @@ The sample file also contains:
 - `APP_BASE_URL`
 - `AUTH_REDIRECT_URI`
 
-Those values may still be useful for external auth-provider setup, but they are not referenced directly by this frontend codebase.
+Those values may still be useful for external auth-provider setup, but they are not referenced directly by this frontend codebase. The effective NextAuth callback URL is derived from `NEXTAUTH_URL`, so the corresponding `/api/auth/callback/zitadel` URL must also be registered on the ZITADEL application.
+
+Do not include leading or trailing whitespace in credentials or URLs. In particular, whitespace in `AUTH_CLIENT_SECRET` changes the secret value and will make OAuth token exchanges fail.
 
 Example local configuration:
 
 ```dotenv
 NEXT_PUBLIC_BASE_URL=http://localhost:4000
+NEXTAUTH_URL=http://localhost:3000
 AUTH_SECRET=replace-with-a-long-random-secret
 AUTH_ISSUER_URL=https://auth.example.com
 AUTH_CLIENT_ID=replace-with-your-client-id
 AUTH_CLIENT_SECRET=replace-with-your-client-secret
-AUTH_SCOPES=openid email profile
+AUTH_SCOPES=openid email profile offline_access
 AUTH_POST_LOGOUT_REDIRECT_URI=http://localhost:3000
 AUTH_DEBUG=false
 ```
@@ -234,6 +238,7 @@ pnpm start
 If you deploy behind a reverse proxy or managed platform, ensure:
 
 - HTTPS is enabled
+- `NEXTAUTH_URL` matches the canonical public frontend URL
 - your auth issuer accepts the production callback URL
 - `AUTH_POST_LOGOUT_REDIRECT_URI` matches the deployed frontend URL
 
@@ -243,10 +248,12 @@ If you deploy behind a reverse proxy or managed platform, ensure:
 
 Check:
 
+- `NEXTAUTH_URL`
 - `AUTH_SECRET`
 - `AUTH_ISSUER_URL`
 - `AUTH_CLIENT_ID`
 - `AUTH_CLIENT_SECRET`
+- that none of those values contain accidental whitespace
 - whether the issued access token is expired
 
 The auth helper marks expired tokens with `AccessTokenExpired`, and protected routes will reject them.

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -34,8 +34,10 @@ export function AuthContextProvider({ children, ...props }: AuthContextProviderP
   const revalidate = useCallback(async () => {
     const session = await fetchSession();
     if (!session) {
+      // Being unauthenticated is a valid application state. Redirecting to `/`
+      // from the root layout causes an infinite full-page reload when the
+      // session endpoint returns 401, including for normal logged-out visitors.
       clear();
-      window.location.href = '/';
       return;
     }
 
@@ -63,12 +65,11 @@ async function fetchSession(): Promise<SessionData | null> {
 
   if (res.status === 200) {
     const data = (await res.json()) as SessionData & { user: User };
-    if (data.user.requires_account_resolution) {
-      if (window.location.pathname !== '/account/resolve') {
-        window.location.href = '/account/resolve';
-        return null;
-      }
-      return data;
+    if (
+      data.user.requires_account_resolution &&
+      window.location.pathname !== '/account/resolve'
+    ) {
+      window.location.href = '/account/resolve';
     }
     return data;
   }


### PR DESCRIPTION
## Summary
- treat an unauthenticated `/api/auth/session` 401 as a normal logged-out state instead of forcing a full-page redirect to `/`
- keep account-resolution navigation without returning a false missing-session result
- document `NEXTAUTH_URL`, `offline_access`, and accidental whitespace risks in auth environment values
- align `.env.example` with the production NextAuth variables already used by the deployment

## Root cause
`AuthContextProvider` is mounted from the root layout. On every mount it revalidates `/api/auth/session`. A 401 returned `null`, and `revalidate()` immediately assigned `window.location.href = '/'`. When the current page was already `/`, that caused a full reload, remounted the provider, fetched the same 401, and repeated forever.

A 401 from this route is expected for a logged-out visitor; the route only returns 401 when there is no NextAuth user or no usable provider access token. The browser auth context should clear its local state, not navigate globally.

## Environment review
The production values supplied for `NEXTAUTH_URL`, `AUTH_ISSUER_URL`, `NEXT_PUBLIC_BASE_URL`, `AUTH_SCOPES`, and `AUTH_ROLE_CLAIM` match the current code. `APP_BASE_URL` and `AUTH_REDIRECT_URI` remain useful operator/reference values but are not directly consumed by the frontend code. Credentials and URLs must not contain leading/trailing whitespace, especially `AUTH_CLIENT_SECRET`.

## Validation
- branch is based directly on current `main`
- diff is limited to `src/contexts/AuthContext.tsx`, `.env.example`, and `README.md`
- no auth secret values are committed

CI should run the repository lint/typecheck/test/build checks on the PR.