### PR TITLE
chore(deploy): add Docker Compose for Coolify

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+.next
+node_modules
+coverage
+.env
+.env.*
+!.env.example
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+README.md

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,68 @@
+# Deployment
+
+The production container is defined by `Dockerfile` and `compose.yml`.
+
+## Coolify
+
+Deploy the repository as a Docker Compose resource using `compose.yml`.
+
+The compose service listens on port `3000` inside the Docker network. Coolify should attach the public domain to the `web` service on port `3000`; the application does not publish a host port directly.
+
+Coolify provides `COOLIFY_URL` for the configured public application URL. The compose file uses it directly for both:
+
+- `NEXTAUTH_URL`
+- `AUTH_POST_LOGOUT_REDIRECT_URI`
+
+This means changing the application's canonical domain in Coolify updates those runtime values without editing the repository or duplicating the frontend URL in environment variables.
+
+Configure these variables in Coolify:
+
+```dotenv
+AUTH_SECRET=...
+AUTH_ISSUER_URL=https://auth.nei-isep.org
+AUTH_CLIENT_ID=...
+AUTH_CLIENT_SECRET=...
+AUTH_SCOPES="openid email profile offline_access urn:zitadel:iam:org:project:id:<ANTIRECURSO_PROJECT_ID>:aud"
+AUTH_ROLE_CLAIM=urn:zitadel:iam:org:project:roles
+AUTH_DEBUG=false
+NEXT_PUBLIC_BASE_URL=https://antirecurso-api.nei-isep.org
+```
+
+`NEXT_PUBLIC_BASE_URL` is passed both to the Docker build and to the runtime container because Next.js embeds `NEXT_PUBLIC_*` values into browser bundles at build time.
+
+Do not add `APP_BASE_URL` or `AUTH_REDIRECT_URI`; the frontend does not consume them. The effective callback URL is always:
+
+```text
+<COOLIFY_URL>/api/auth/callback/zitadel
+```
+
+When the public domain changes, Coolify updates `COOLIFY_URL`, but ZITADEL still needs the new callback URL and post-logout URL registered on the AntiRecurso OIDC application.
+
+## Local Docker Compose
+
+Outside Coolify, define `COOLIFY_URL` yourself because the compose file deliberately uses the same canonical-URL variable in every environment:
+
+```dotenv
+COOLIFY_URL=http://localhost:3000
+NEXT_PUBLIC_BASE_URL=http://host.docker.internal:4000
+AUTH_SECRET=...
+AUTH_ISSUER_URL=https://auth.example.com
+AUTH_CLIENT_ID=...
+AUTH_CLIENT_SECRET=...
+AUTH_SCOPES="openid email profile offline_access urn:zitadel:iam:org:project:id:<PROJECT_ID>:aud"
+```
+
+The production compose file only exposes port `3000` to the Docker network. For direct local browser access, add a local override such as:
+
+```yaml
+services:
+  web:
+    ports:
+      - "3000:3000"
+```
+
+Then run:
+
+```bash
+docker compose up --build
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:22-alpine AS base
+WORKDIR /app
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+RUN corepack enable
+
+FROM base AS deps
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+FROM base AS builder
+ARG NEXT_PUBLIC_BASE_URL
+ENV NEXT_PUBLIC_BASE_URL=$NEXT_PUBLIC_BASE_URL
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN pnpm build
+
+FROM base AS runner
+ENV NODE_ENV=production
+ENV HOSTNAME=0.0.0.0
+ENV PORT=3000
+
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/pnpm-lock.yaml ./pnpm-lock.yaml
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
+
+EXPOSE 3000
+CMD ["pnpm", "start"]

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,36 @@
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL}
+    environment:
+      NODE_ENV: production
+      PORT: 3000
+      HOSTNAME: 0.0.0.0
+      NEXTAUTH_URL: ${COOLIFY_URL}
+      AUTH_POST_LOGOUT_REDIRECT_URI: ${COOLIFY_URL}
+      AUTH_SECRET: ${AUTH_SECRET}
+      AUTH_ISSUER_URL: ${AUTH_ISSUER_URL}
+      AUTH_CLIENT_ID: ${AUTH_CLIENT_ID}
+      AUTH_CLIENT_SECRET: ${AUTH_CLIENT_SECRET}
+      AUTH_SCOPES: ${AUTH_SCOPES:-openid email profile offline_access}
+      AUTH_ROLE_CLAIM: ${AUTH_ROLE_CLAIM:-urn:zitadel:iam:org:project:roles}
+      AUTH_DEBUG: ${AUTH_DEBUG:-false}
+      NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL}
+    expose:
+      - "3000"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://127.0.0.1:3000/').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- add a production multi-stage `Dockerfile` for the Next.js frontend
- add `compose.yml` for Coolify with internal port `3000`, restart policy, and healthcheck
- derive `NEXTAUTH_URL` and `AUTH_POST_LOGOUT_REDIRECT_URI` directly from Coolify's `COOLIFY_URL`
- pass `NEXT_PUBLIC_BASE_URL` at build time and runtime
- add `.dockerignore` and deployment documentation

## Coolify
Deploy this repository as a Docker Compose resource using `compose.yml` and attach the public domain to service `web` on port `3000`.

Required environment variables remain secrets/configuration in Coolify. The frontend URL itself no longer needs to be duplicated into `NEXTAUTH_URL` or `AUTH_POST_LOGOUT_REDIRECT_URI`; both come from `COOLIFY_URL`.

Changing the domain in Coolify therefore updates the application-side canonical URL automatically. ZITADEL redirect and post-logout allowlists still need to contain the new domain.

## Validation
- compose YAML parsed successfully
- branch is based on current `main` and is 0 commits behind
- no secrets or production credentials committed
