### PR TITLE
fix(deploy): use Coolify service URL variables

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -8,12 +8,16 @@ Deploy the repository as a Docker Compose resource using `compose.yml`.
 
 The compose service listens on port `3000` inside the Docker network. Coolify should attach the public domain to the `web` service on port `3000`; the application does not publish a host port directly.
 
-Coolify provides `COOLIFY_URL` for the configured public application URL. The compose file uses it directly for both:
+The compose file uses Coolify's generated service URL variable for the `web` service on port `3000`:
+
+- `SERVICE_URL_WEB_3000`
+
+It is mapped automatically to both:
 
 - `NEXTAUTH_URL`
 - `AUTH_POST_LOGOUT_REDIRECT_URI`
 
-This means changing the application's canonical domain in Coolify updates those runtime values without editing the repository or duplicating the frontend URL in environment variables.
+This means changing the service domain in Coolify updates those runtime values without duplicating the frontend URL in application environment variables.
 
 Configure these variables in Coolify:
 
@@ -28,22 +32,24 @@ AUTH_DEBUG=false
 NEXT_PUBLIC_BASE_URL=https://antirecurso-api.nei-isep.org
 ```
 
+The compose file marks `AUTH_SECRET`, `AUTH_ISSUER_URL`, `AUTH_CLIENT_ID`, `AUTH_CLIENT_SECRET`, `AUTH_SCOPES`, and `NEXT_PUBLIC_BASE_URL` as required. `AUTH_ROLE_CLAIM` and `AUTH_DEBUG` retain safe defaults.
+
 `NEXT_PUBLIC_BASE_URL` is passed both to the Docker build and to the runtime container because Next.js embeds `NEXT_PUBLIC_*` values into browser bundles at build time.
 
 Do not add `APP_BASE_URL` or `AUTH_REDIRECT_URI`; the frontend does not consume them. The effective callback URL is always:
 
 ```text
-<COOLIFY_URL>/api/auth/callback/zitadel
+<SERVICE_URL_WEB_3000>/api/auth/callback/zitadel
 ```
 
-When the public domain changes, Coolify updates `COOLIFY_URL`, but ZITADEL still needs the new callback URL and post-logout URL registered on the AntiRecurso OIDC application.
+When the public domain changes, Coolify updates the generated service URL, but ZITADEL still needs the new callback URL and post-logout URL registered on the AntiRecurso OIDC application.
 
 ## Local Docker Compose
 
-Outside Coolify, define `COOLIFY_URL` yourself because the compose file deliberately uses the same canonical-URL variable in every environment:
+Outside Coolify, define `SERVICE_URL_WEB_3000` yourself because the production compose file deliberately uses the same canonical URL variable everywhere:
 
 ```dotenv
-COOLIFY_URL=http://localhost:3000
+SERVICE_URL_WEB_3000=http://localhost:3000
 NEXT_PUBLIC_BASE_URL=http://host.docker.internal:4000
 AUTH_SECRET=...
 AUTH_ISSUER_URL=https://auth.example.com

--- a/compose.yml
+++ b/compose.yml
@@ -4,21 +4,21 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL}
+        NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:?}
     environment:
       NODE_ENV: production
       PORT: 3000
       HOSTNAME: 0.0.0.0
-      NEXTAUTH_URL: ${COOLIFY_URL}
-      AUTH_POST_LOGOUT_REDIRECT_URI: ${COOLIFY_URL}
-      AUTH_SECRET: ${AUTH_SECRET}
-      AUTH_ISSUER_URL: ${AUTH_ISSUER_URL}
-      AUTH_CLIENT_ID: ${AUTH_CLIENT_ID}
-      AUTH_CLIENT_SECRET: ${AUTH_CLIENT_SECRET}
-      AUTH_SCOPES: ${AUTH_SCOPES:-openid email profile offline_access}
+      NEXTAUTH_URL: ${SERVICE_URL_WEB_3000}
+      AUTH_POST_LOGOUT_REDIRECT_URI: ${SERVICE_URL_WEB_3000}
+      AUTH_SECRET: ${AUTH_SECRET:?}
+      AUTH_ISSUER_URL: ${AUTH_ISSUER_URL:?}
+      AUTH_CLIENT_ID: ${AUTH_CLIENT_ID:?}
+      AUTH_CLIENT_SECRET: ${AUTH_CLIENT_SECRET:?}
+      AUTH_SCOPES: ${AUTH_SCOPES:?}
       AUTH_ROLE_CLAIM: ${AUTH_ROLE_CLAIM:-urn:zitadel:iam:org:project:roles}
       AUTH_DEBUG: ${AUTH_DEBUG:-false}
-      NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL}
+      NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:?}
     expose:
       - "3000"
     healthcheck:


### PR DESCRIPTION
## Summary
- replace `COOLIFY_URL` with Coolify's generated `SERVICE_URL_WEB_3000` magic variable
- map the generated service URL to `NEXTAUTH_URL` and `AUTH_POST_LOGOUT_REDIRECT_URI`
- mark required deployment variables with `${VAR:?}` so Coolify surfaces them as mandatory
- remove the incomplete default for `AUTH_SCOPES`; it must include the AntiRecurso project audience scope
- update deployment documentation for Coolify and local Compose usage

## Required Coolify variables
- `AUTH_SECRET`
- `AUTH_ISSUER_URL`
- `AUTH_CLIENT_ID`
- `AUTH_CLIENT_SECRET`
- `AUTH_SCOPES`
- `NEXT_PUBLIC_BASE_URL`

Defaults remain for:
- `AUTH_ROLE_CLAIM=urn:zitadel:iam:org:project:roles`
- `AUTH_DEBUG=false`

`AUTH_SCOPES` should be configured as:

```text
openid email profile offline_access urn:zitadel:iam:org:project:id:<ANTIRECURSO_PROJECT_ID>:aud
```

The frontend canonical URL no longer needs to be entered manually; Coolify generates it through `SERVICE_URL_WEB_3000`.