### PR TITLE
fix(deploy): derive backend proxy URL from Coolify

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -8,12 +8,13 @@ Deploy the repository as a Docker Compose resource using `compose.yml`.
 
 The compose service listens on port `3000` inside the Docker network. Coolify should attach the public domain to the `web` service on port `3000`; the application does not publish a host port directly.
 
-Coolify predefines `COOLIFY_URL` as the application URL. The compose file uses it as the canonical frontend URL:
+Coolify predefines `COOLIFY_URL` as the application URL. The compose file derives the frontend URLs from it:
 
-- `NEXTAUTH_URL` always uses `COOLIFY_URL`
+- `NEXTAUTH_URL` uses `COOLIFY_URL`
 - `AUTH_POST_LOGOUT_REDIRECT_URI` defaults to `COOLIFY_URL`, but can be overridden explicitly
+- `NEXT_PUBLIC_BASE_URL` uses `<COOLIFY_URL>/api/backend`, the frontend's authenticated backend proxy
 
-This means changing the application's public URL in Coolify updates the normal login/logout URLs without duplicating the frontend URL in application environment variables.
+This means changing the application's public URL in Coolify updates the normal login/logout URLs and the browser-facing backend proxy URL without duplicating the frontend domain in application environment variables.
 
 Configure these variables in Coolify:
 
@@ -25,7 +26,6 @@ AUTH_CLIENT_SECRET=...
 AUTH_SCOPES="openid email profile offline_access urn:zitadel:iam:org:project:id:<ANTIRECURSO_PROJECT_ID>:aud"
 AUTH_ROLE_CLAIM=urn:zitadel:iam:org:project:roles
 AUTH_DEBUG=false
-NEXT_PUBLIC_BASE_URL=https://antirecurso-api.nei-isep.org
 ```
 
 Optionally override the logout destination only if it should differ from the application URL:
@@ -34,9 +34,9 @@ Optionally override the logout destination only if it should differ from the app
 AUTH_POST_LOGOUT_REDIRECT_URI=https://example.com
 ```
 
-The compose file marks `AUTH_SECRET`, `AUTH_ISSUER_URL`, `AUTH_CLIENT_ID`, `AUTH_CLIENT_SECRET`, `AUTH_SCOPES`, and `NEXT_PUBLIC_BASE_URL` as required. `AUTH_ROLE_CLAIM` and `AUTH_DEBUG` retain safe defaults.
+The compose file marks `AUTH_SECRET`, `AUTH_ISSUER_URL`, `AUTH_CLIENT_ID`, `AUTH_CLIENT_SECRET`, and `AUTH_SCOPES` as required. `AUTH_ROLE_CLAIM` and `AUTH_DEBUG` retain safe defaults.
 
-`NEXT_PUBLIC_BASE_URL` is passed both to the Docker build and to the runtime container because Next.js embeds `NEXT_PUBLIC_*` values into browser bundles at build time.
+`NEXT_PUBLIC_BASE_URL` is passed both to the Docker build and to the runtime container because Next.js embeds `NEXT_PUBLIC_*` values into browser bundles at build time. In Coolify it is derived automatically as `<COOLIFY_URL>/api/backend`.
 
 Do not add `APP_BASE_URL` or `AUTH_REDIRECT_URI`; the frontend does not consume them. The effective callback URL is always:
 
@@ -48,17 +48,18 @@ When the public domain changes, Coolify updates `COOLIFY_URL`, but ZITADEL still
 
 ## Local Docker Compose
 
-Outside Coolify, define `COOLIFY_URL` yourself because the production compose file deliberately uses the same canonical URL variable everywhere:
+Outside Coolify, define `COOLIFY_URL` yourself because the production compose file deliberately derives its public URLs from the same canonical value:
 
 ```dotenv
 COOLIFY_URL=http://localhost:3000
-NEXT_PUBLIC_BASE_URL=http://host.docker.internal:4000
 AUTH_SECRET=...
 AUTH_ISSUER_URL=https://auth.example.com
 AUTH_CLIENT_ID=...
 AUTH_CLIENT_SECRET=...
 AUTH_SCOPES="openid email profile offline_access urn:zitadel:iam:org:project:id:<PROJECT_ID>:aud"
 ```
+
+With that configuration, `NEXT_PUBLIC_BASE_URL` becomes `http://localhost:3000/api/backend`.
 
 The production compose file only exposes port `3000` to the Docker network. For direct local browser access, add a local override such as:
 

--- a/compose.yml
+++ b/compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:?}
+        NEXT_PUBLIC_BASE_URL: ${COOLIFY_URL}/api/backend
     environment:
       NODE_ENV: production
       PORT: 3000
@@ -18,7 +18,7 @@ services:
       AUTH_SCOPES: ${AUTH_SCOPES:?}
       AUTH_ROLE_CLAIM: ${AUTH_ROLE_CLAIM:-urn:zitadel:iam:org:project:roles}
       AUTH_DEBUG: ${AUTH_DEBUG:-false}
-      NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:?}
+      NEXT_PUBLIC_BASE_URL: ${COOLIFY_URL}/api/backend
     expose:
       - "3000"
     healthcheck:


### PR DESCRIPTION
## Summary
- derive `NEXT_PUBLIC_BASE_URL` from Coolify's predefined `COOLIFY_URL`
- use `<COOLIFY_URL>/api/backend` for both Docker build-time and runtime values
- remove `NEXT_PUBLIC_BASE_URL` from the list of required Coolify variables
- keep `AUTH_POST_LOGOUT_REDIRECT_URI` overrideable with `COOLIFY_URL` as its default
- update deployment documentation accordingly

This matches the frontend's authenticated backend proxy route at `/api/backend`, so changing the public AntiRecurso domain in Coolify also updates the browser-facing backend base URL automatically.