### PR TITLE
chore(ci): remove duplicate workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [dev, main]
-  push:
-    branches: [dev, main]
   workflow_dispatch:
 
 permissions:
@@ -48,9 +46,3 @@ jobs:
 
       - name: Reject critical production dependency advisories
         run: pnpm audit --prod --audit-level=critical
-
-  secret-scan:
-    name: Secret scan
-    runs-on: ubuntu-latest
-    steps:
-      - uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/actions/secret-scan@master

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,3 +11,11 @@ jobs:
     uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/workflows/dependency-review.yml@master
     permissions:
       contents: read
+
+  secret-scan:
+    name: Secret scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/actions/secret-scan@master


### PR DESCRIPTION
## Summary

Normalize Antirecurso against the organization workflow standard introduced in `Nucleo-Estudantes-Informatica-ISEP/.github#7` while preserving the status-check contexts expected by the repository ruleset.

### CI
- keep Antirecurso-specific lint/typecheck/test/build jobs local
- remove the redundant full-CI `push` trigger for `dev`/`main`; the full suite now runs on PRs (or manually) instead of repeating after every merge
- remove `Secret scan` from the application CI workflow

### Security
- keep `dependency-review / Dependency review` backed by the central reusable dependency-review workflow
- move the organization-standard `Secret scan` into `security.yml`
- keep the existing `Secret scan` context name so `main` branch protection/rulesets remain compatible

### Release
- no change: Antirecurso already uses the centralized release policy/publish actions via a minimal local wrapper, and preserving the existing `validate-release-label` context avoids unnecessary ruleset churn

## Intended result

- feature -> `dev` PR: Antirecurso CI + dependency review + secret scan once
- merge -> `dev`: no second copy of the full quality suite
- `dev` -> `main` PR: Antirecurso CI + security + release policy
- merge -> `main`: semantic release publication only

## Scope

No application/runtime code changes are included. This PR changes only `.github/workflows/ci.yml` and `.github/workflows/security.yml`.