### PR TITLE
fix(auth): prevent stale Coolify scopes breaking session

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -24,12 +24,13 @@ services:
       AUTH_CLIENT_ID: ${AUTH_CLIENT_ID:?Configure AUTH_CLIENT_ID in Coolify}
       AUTH_CLIENT_SECRET: ${AUTH_CLIENT_SECRET:?Configure AUTH_CLIENT_SECRET in Coolify}
 
-      # These IDs come from the AuthNEI bootstrap output. The application project
-      # is the API audience; NEI Global carries the shared admin role.
+      # These IDs come from the AuthNEI bootstrap output. Keep the derived scopes
+      # deterministic so stale Coolify AUTH_SCOPES/AUTH_ROLE_CLAIM values cannot
+      # silently remove the API audience and break authenticated backend calls.
       AUTH_PROJECT_ID: ${AUTH_PROJECT_ID:?Configure AUTH_PROJECT_ID in Coolify}
       AUTH_GLOBAL_PROJECT_ID: ${AUTH_GLOBAL_PROJECT_ID:?Configure AUTH_GLOBAL_PROJECT_ID in Coolify}
-      AUTH_SCOPES: ${AUTH_SCOPES:-openid email profile offline_access urn:zitadel:iam:org:projects:roles urn:zitadel:iam:org:project:id:${AUTH_PROJECT_ID}:aud urn:zitadel:iam:org:project:id:${AUTH_GLOBAL_PROJECT_ID}:aud}
-      AUTH_ROLE_CLAIM: ${AUTH_ROLE_CLAIM:-urn:zitadel:iam:org:project:${AUTH_GLOBAL_PROJECT_ID}:roles}
+      AUTH_SCOPES: openid email profile offline_access urn:zitadel:iam:org:projects:roles urn:zitadel:iam:org:project:id:${AUTH_PROJECT_ID}:aud urn:zitadel:iam:org:project:id:${AUTH_GLOBAL_PROJECT_ID}:aud
+      AUTH_ROLE_CLAIM: urn:zitadel:iam:org:project:${AUTH_GLOBAL_PROJECT_ID}:roles
       AUTH_DEBUG: ${AUTH_DEBUG:-false}
 
       # NEXT_PUBLIC_BASE_URL is the external Adonis API. Authenticated browser

--- a/src/lib/deployment-config.test.ts
+++ b/src/lib/deployment-config.test.ts
@@ -24,4 +24,12 @@ describe('Coolify deployment configuration', () => {
     expect(compose).toContain('urn:zitadel:iam:org:projects:roles');
     expect(compose).toContain('urn:zitadel:iam:org:project:${AUTH_GLOBAL_PROJECT_ID}:roles');
   });
+
+  it('does not allow stale Coolify auth scope overrides', () => {
+    expect(compose).not.toContain('AUTH_SCOPES: ${AUTH_SCOPES:-');
+    expect(compose).not.toContain('AUTH_ROLE_CLAIM: ${AUTH_ROLE_CLAIM:-');
+    expect(compose).toContain(
+      'urn:zitadel:iam:org:project:id:${AUTH_PROJECT_ID}:aud'
+    );
+  });
 });


### PR DESCRIPTION
## Root cause

`/api/auth/session` calls the AntiRecurso API `GET /user` with the ZITADEL access token. The frontend Compose still allowed an existing Coolify `AUTH_SCOPES` value to override the derived AuthNEI scopes. A stale value such as `openid email profile offline_access` omits the AntiRecurso project audience, so the API rejects the access token and the frontend session route converts that upstream failure into HTTP 502.

## Fix

- make `AUTH_SCOPES` deterministic in Compose from `AUTH_PROJECT_ID` and `AUTH_GLOBAL_PROJECT_ID`
- make `AUTH_ROLE_CLAIM` deterministic from `AUTH_GLOBAL_PROJECT_ID`
- prevent stale Coolify `AUTH_SCOPES` / `AUTH_ROLE_CLAIM` values from overriding the deployment configuration
- add regression coverage for the deterministic audience scope

This keeps local `.env` usage unchanged while making Coolify deployments immune to stale saved auth scope values.