### PR TITLE
fix(auth): align account menu with AuthNEI SSO

### DIFF
--- a/src/app/api/auth/profile/route.ts
+++ b/src/app/api/auth/profile/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  const issuer = process.env.AUTH_ISSUER_URL?.replace(/\/$/, '');
+
+  if (!issuer) {
+    return NextResponse.redirect(new URL('/', request.nextUrl.origin));
+  }
+
+  return NextResponse.redirect(new URL('/ui/console/users/me', `${issuer}/`));
+}

--- a/src/components/navbar/HamburgerMenu/index.tsx
+++ b/src/components/navbar/HamburgerMenu/index.tsx
@@ -139,10 +139,10 @@ const HamburgerMenu: React.FC = () => {
             {session.user ? (
               <>
                 <Button asChild variant="default" className="w-full" onClick={close}>
-                  <a href="/api/auth/profile">
+                  <Link href="/api/auth/profile">
                     <UserCog className="size-4" />
                     Gerir perfil
-                  </a>
+                  </Link>
                 </Button>
                 <Button variant="outline" className="w-full" onClick={handleSwitchAccount}>
                   <RefreshCw className="size-4" />

--- a/src/components/navbar/HamburgerMenu/index.tsx
+++ b/src/components/navbar/HamburgerMenu/index.tsx
@@ -5,8 +5,9 @@ import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import ThemeChanger from '@/components/utils/Theme/ThemeChanger';
 import useSession from '@/hooks/useSession';
+import { switchAuthNeiAccount } from '@/lib/client-auth-actions';
 import { cn } from '@/lib/utils';
-import { LogIn, LogOut, Menu, RefreshCw, User, UserPlus } from 'lucide-react';
+import { LogIn, LogOut, Menu, RefreshCw, UserCog, UserPlus } from 'lucide-react';
 import { signOut } from 'next-auth/react';
 import { useTheme } from 'next-themes';
 import Link from 'next/link';
@@ -14,7 +15,6 @@ import { usePathname, useRouter } from 'next/navigation';
 import { useState } from 'react';
 import swal from 'sweetalert';
 import { topBarLinks } from '../Topbar';
-import { signOutFromApp, switchAuthNeiAccount } from '@/lib/client-auth-actions';
 
 const HamburgerMenu: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -61,12 +61,6 @@ const HamburgerMenu: React.FC = () => {
         className: theme === 'dark' ? 'swal-dark' : ''
       });
     }
-  };
-
-  const handleAppLogout = async () => {
-    close();
-    session.clear();
-    await signOutFromApp('/');
   };
 
   const handleSwitchAccount = async () => {
@@ -145,14 +139,10 @@ const HamburgerMenu: React.FC = () => {
             {session.user ? (
               <>
                 <Button asChild variant="default" className="w-full" onClick={close}>
-                  <Link href="/profile">
-                    <User className="size-4" />
-                    Aceder ao perfil
-                  </Link>
-                </Button>
-                <Button variant="outline" className="w-full" onClick={handleAppLogout}>
-                  <LogOut className="size-4" />
-                  Sair apenas do AntiRecurso
+                  <a href="/api/auth/profile">
+                    <UserCog className="size-4" />
+                    Gerir perfil
+                  </a>
                 </Button>
                 <Button variant="outline" className="w-full" onClick={handleSwitchAccount}>
                   <RefreshCw className="size-4" />
@@ -164,7 +154,7 @@ const HamburgerMenu: React.FC = () => {
                   onClick={handleLogout}
                 >
                   <LogOut className="size-4" />
-                  Terminar sessão no AuthNEI
+                  Terminar sessão
                 </Button>
               </>
             ) : (

--- a/src/components/navbar/HamburguerProfileMenu/index.tsx
+++ b/src/components/navbar/HamburguerProfileMenu/index.tsx
@@ -127,10 +127,10 @@ const HamburgerProfileMenu: React.FC = () => {
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
         <DropdownMenuItem asChild>
-          <a href="/api/auth/profile" className="cursor-pointer">
+          <Link href="/api/auth/profile" className="cursor-pointer">
             <UserCog className="size-4" />
             <span>Gerir perfil</span>
-          </a>
+          </Link>
         </DropdownMenuItem>
         <DropdownMenuItem onClick={handleSwitchAccount} className="cursor-pointer">
           <RefreshCw className="size-4" />

--- a/src/components/navbar/HamburguerProfileMenu/index.tsx
+++ b/src/components/navbar/HamburguerProfileMenu/index.tsx
@@ -12,13 +12,13 @@ import {
 } from '@/components/ui/dropdown-menu';
 import useCallbackUrl from '@/hooks/useCallbackUrl';
 import useSession from '@/hooks/useSession';
-import { LogIn, LogOut, RefreshCw, User, UserPlus } from 'lucide-react';
-import { useTheme } from 'next-themes';
+import { switchAuthNeiAccount } from '@/lib/client-auth-actions';
+import { LogIn, LogOut, RefreshCw, UserCog, UserPlus } from 'lucide-react';
 import { signOut } from 'next-auth/react';
+import { useTheme } from 'next-themes';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import swal from 'sweetalert';
-import { signOutFromApp, switchAuthNeiAccount } from '@/lib/client-auth-actions';
 
 const HamburgerProfileMenu: React.FC = () => {
   const pathname = useCallbackUrl();
@@ -74,11 +74,6 @@ const HamburgerProfileMenu: React.FC = () => {
     }
   };
 
-  const handleAppLogout = async () => {
-    session.clear();
-    await signOutFromApp('/');
-  };
-
   const handleSwitchAccount = async () => {
     session.clear();
     await switchAuthNeiAccount(pathname || '/');
@@ -132,15 +127,10 @@ const HamburgerProfileMenu: React.FC = () => {
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
         <DropdownMenuItem asChild>
-          <Link href="/profile" className="cursor-pointer">
-            <User className="size-4" />
-            <span>O meu perfil</span>
-          </Link>
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem onClick={handleAppLogout} className="cursor-pointer">
-          <LogOut className="size-4" />
-          <span>Sair apenas do AntiRecurso</span>
+          <a href="/api/auth/profile" className="cursor-pointer">
+            <UserCog className="size-4" />
+            <span>Gerir perfil</span>
+          </a>
         </DropdownMenuItem>
         <DropdownMenuItem onClick={handleSwitchAccount} className="cursor-pointer">
           <RefreshCw className="size-4" />
@@ -151,7 +141,7 @@ const HamburgerProfileMenu: React.FC = () => {
           className="cursor-pointer text-destructive focus:text-destructive"
         >
           <LogOut className="size-4" />
-          <span>Terminar sessão no AuthNEI</span>
+          <span>Terminar sessão</span>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/components/navbar/LogoutButton/index.tsx
+++ b/src/components/navbar/LogoutButton/index.tsx
@@ -69,7 +69,7 @@ const LogoutButton: React.FC<LogoutButtonProps> = ({ className, onClick }) => {
       onClick={logoutButtonHandler}
     >
       <LogOut className="size-4" />
-      Terminar sessão no AuthNEI
+      Terminar sessão
     </Button>
   );
 };


### PR DESCRIPTION
## Summary

- align the AntiRecurso account menu with the centralized AuthNEI SSO UX
- replace the local-profile account action with **Gerir perfil**, redirecting to the authenticated ZITADEL self-service profile at `/ui/console/users/me`
- keep **Trocar de conta** using the existing OIDC `prompt=select_account` flow
- remove **Sair apenas do AntiRecurso** from desktop and mobile account menus
- rename the full SSO logout action to **Terminar sessão** while preserving the existing AuthNEI end-session flow
- keep the AntiRecurso `/profile` page itself intact because it contains app-specific scores/exam history

## Result

The account actions are now consistently:

1. **Gerir perfil** — centralized AuthNEI account management
2. **Trocar de conta** — account selector
3. **Terminar sessão** — local session + AuthNEI logout
