### PR TITLE
chore: centralize secret scanning and harden environment storage

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,20 +2,19 @@ name: Security
 
 on:
   pull_request:
-    branches: [dev, main]
   workflow_dispatch:
+    inputs:
+      full_history:
+        description: Scan all reachable history instead of the latest change.
+        required: false
+        type: boolean
+        default: true
 
 jobs:
-  dependency-review:
-    if: github.event_name == 'pull_request'
-    uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/workflows/dependency-review.yml@master
+  security:
+    name: Security
     permissions:
       contents: read
-
-  secret-scan:
-    name: Secret scan
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/actions/secret-scan@master
+    uses: Nucleo-Estudantes-Informatica-ISEP/.github/.github/workflows/security.yml@master
+    with:
+      full_history: ${{ github.event_name == 'workflow_dispatch' && inputs.full_history || false }}

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ next-env.d.ts
 
 .env
 .env.local
+
+# Local environment files (NEI)
+.env*
+!.env.example
+!**/.env.example

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,12 @@
+title = "Antirecurso Gitleaks configuration"
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "React list keys in the static changelog are UI identifiers, not API keys."
+targetRules = ["generic-api-key"]
+condition = "AND"
+paths = ['''(^|/)src/app/\(guest\)/changelog/page\.tsx$''']
+regexTarget = "match"
+regexes = ['''key="[0-9]+\.[0-9]+\.[0-9]+-[a-z0-9-]+"''']


### PR DESCRIPTION
## Summary

Add a detector/path/pattern-scoped exception for verified React list-key false positives; no credential findings are suppressed.

Use the canonical reusable Security workflow with an explicit manual full-history input. Ignore operational `.env*` files while permitting reviewed `.env.example` placeholders.

## Validation

- [x] Workflow syntax and staged redacted secret scan passed
- [ ] Hosted required checks and maintainer review complete

Workflow-only/configuration changes: actionlint and staged Gitleaks 8.30.1 passed. Application suites were not run locally.

## Release impact

release:patch — security tooling configuration; required by the existing release policy for .gitleaks.toml changes.

## Deployment / migration notes

Merge the central .github remediation first to activate the corrected manual full-history implementation. Preserve existing application checks when migrating Security status contexts.

## Manual actions

Provider login/rotation and production verification are not performed by this PR. Review retained provider logs and record unavailable retention. Do not resolve secret alerts as revoked until provider-side revocation and old-credential rejection are proven. Historical findings remain pending that evidence; no history rewrite or scan bypass is included.

## Issues

No incident is closed by this code-only PR.
