### PR TITLE
feat(profile): separate app profile from AuthNEI account

### DIFF
--- a/src/app/(guest)/profile/page.tsx
+++ b/src/app/(guest)/profile/page.tsx
@@ -6,7 +6,14 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { getServerSession, getUserScores, getPendingExams } from '@/services/getServerSession';
-import { ArrowRight, BookOpenCheck, CalendarDays, GraduationCap, History, Settings } from 'lucide-react';
+import {
+  ArrowRight,
+  BookOpenCheck,
+  CalendarDays,
+  GraduationCap,
+  History,
+  Settings
+} from 'lucide-react';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
 
@@ -39,6 +46,7 @@ const Profile: React.FC = async () => {
             <h1 className="text-2xl md:text-3xl font-bold tracking-tight">
               Boas vindas, <span className="text-primary">{user.name}</span>
             </h1>
+            <p className="mt-1 text-sm text-muted-foreground">{user.email}</p>
             <p className="mt-2 text-muted-foreground inline-flex items-center gap-2 text-sm">
               <CalendarDays className="size-4" />
               Hoje é dia {today}. Tens algum exame perto?
@@ -57,19 +65,20 @@ const Profile: React.FC = async () => {
                   Ver resumos
                 </Link>
               </Button>
-              {process.env.AUTH_ISSUER_URL && (
-                <Button asChild variant="ghost" className="text-muted-foreground hover:text-foreground">
-                  <a
-                    href={`${process.env.AUTH_ISSUER_URL}/ui/console`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <Settings className="size-4" />
-                    Gerir conta
-                  </a>
-                </Button>
-              )}
+              <Button
+                asChild
+                variant="ghost"
+                className="text-muted-foreground hover:text-foreground"
+              >
+                <Link href="/api/auth/profile">
+                  <Settings className="size-4" />
+                  Gerir Conta no AuthNEI
+                </Link>
+              </Button>
             </div>
+            <p className="mt-3 text-xs text-muted-foreground">
+              Nome, email e imagem são geridos pelo AuthNEI.
+            </p>
           </div>
         </CardContent>
       </Card>
@@ -84,9 +93,7 @@ const Profile: React.FC = async () => {
                 </div>
                 <div>
                   <h2 className="text-lg md:text-xl font-bold">Exames por terminar</h2>
-                  <p className="text-xs md:text-sm text-muted-foreground">
-                    Continua onde paraste
-                  </p>
+                  <p className="text-xs md:text-sm text-muted-foreground">Continua onde paraste</p>
                 </div>
               </div>
               <PendingExamsTable />

--- a/src/app/(guest)/profile/page.tsx
+++ b/src/app/(guest)/profile/page.tsx
@@ -70,10 +70,12 @@ const Profile: React.FC = async () => {
                 variant="ghost"
                 className="text-muted-foreground hover:text-foreground"
               >
-                <Link href="/api/auth/profile">
+                {/* Full navigation required: endpoint redirects outside the Next.js app. */}
+                {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+                <a href="/api/auth/profile">
                   <Settings className="size-4" />
                   Gerir Conta no AuthNEI
-                </Link>
+                </a>
               </Button>
             </div>
             <p className="mt-3 text-xs text-muted-foreground">

--- a/src/components/navbar/HamburgerMenu/index.tsx
+++ b/src/components/navbar/HamburgerMenu/index.tsx
@@ -2,12 +2,13 @@
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import ThemeChanger from '@/components/utils/Theme/ThemeChanger';
 import useSession from '@/hooks/useSession';
 import { switchAuthNeiAccount } from '@/lib/client-auth-actions';
 import { cn } from '@/lib/utils';
-import { LogIn, LogOut, Menu, RefreshCw, UserCog, UserPlus } from 'lucide-react';
+import { LogIn, LogOut, Menu, RefreshCw, User, UserCog, UserPlus } from 'lucide-react';
 import { signOut } from 'next-auth/react';
 import { useTheme } from 'next-themes';
 import Link from 'next/link';
@@ -15,6 +16,7 @@ import { usePathname, useRouter } from 'next/navigation';
 import { useState } from 'react';
 import swal from 'sweetalert';
 import { topBarLinks } from '../Topbar';
+import { APP_PROFILE_LINK, AUTHNEI_ACCOUNT_LINK } from '../profileLinks';
 
 const HamburgerMenu: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -139,9 +141,16 @@ const HamburgerMenu: React.FC = () => {
             {session.user ? (
               <>
                 <Button asChild variant="default" className="w-full" onClick={close}>
-                  <Link href="/api/auth/profile">
+                  <Link href={APP_PROFILE_LINK.href}>
+                    <User className="size-4" />
+                    {APP_PROFILE_LINK.label}
+                  </Link>
+                </Button>
+                <Separator />
+                <Button asChild variant="outline" className="w-full" onClick={close}>
+                  <Link href={AUTHNEI_ACCOUNT_LINK.href}>
                     <UserCog className="size-4" />
-                    Gerir perfil
+                    {AUTHNEI_ACCOUNT_LINK.label}
                   </Link>
                 </Button>
                 <Button variant="outline" className="w-full" onClick={handleSwitchAccount}>

--- a/src/components/navbar/HamburgerMenu/index.tsx
+++ b/src/components/navbar/HamburgerMenu/index.tsx
@@ -148,10 +148,10 @@ const HamburgerMenu: React.FC = () => {
                 </Button>
                 <Separator />
                 <Button asChild variant="outline" className="w-full" onClick={close}>
-                  <Link href={AUTHNEI_ACCOUNT_LINK.href}>
+                  <a href={AUTHNEI_ACCOUNT_LINK.href}>
                     <UserCog className="size-4" />
                     {AUTHNEI_ACCOUNT_LINK.label}
-                  </Link>
+                  </a>
                 </Button>
                 <Button variant="outline" className="w-full" onClick={handleSwitchAccount}>
                   <RefreshCw className="size-4" />

--- a/src/components/navbar/HamburguerProfileMenu/index.test.tsx
+++ b/src/components/navbar/HamburguerProfileMenu/index.test.tsx
@@ -21,6 +21,13 @@ vi.mock('@/hooks/useSession', () => ({
 }));
 vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }) }));
 vi.mock('next-themes', () => ({ useTheme: () => ({ theme: 'light' }) }));
+vi.mock('next/link', () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href} data-next-link="true">
+      {children}
+    </a>
+  )
+}));
 vi.mock('@/components/ui/dropdown-menu', () => ({
   DropdownMenu: ({ children }: { children: React.ReactNode }) => children,
   DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => children,
@@ -40,11 +47,10 @@ describe('authenticated profile menu', () => {
   it('separates the app profile from AuthNEI account management', () => {
     render(<HamburgerProfileMenu />);
 
-    expect(screen.getByRole('link', { name: 'Perfil' })).toHaveAttribute('href', '/profile');
-    expect(screen.getByRole('link', { name: 'Gerir Conta' })).toHaveAttribute(
-      'href',
-      '/api/auth/profile'
-    );
+    expect(screen.getByRole('link', { name: 'Perfil' })).toHaveAttribute('data-next-link', 'true');
+    const accountLink = screen.getByRole('link', { name: 'Gerir Conta' });
+    expect(accountLink).toHaveAttribute('href', '/api/auth/profile');
+    expect(accountLink).not.toHaveAttribute('data-next-link');
     expect(screen.getAllByRole('separator')).toHaveLength(2);
   });
 });

--- a/src/components/navbar/HamburguerProfileMenu/index.test.tsx
+++ b/src/components/navbar/HamburguerProfileMenu/index.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment happy-dom
+/// <reference types="@testing-library/jest-dom" />
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/hooks/useCallbackUrl', () => ({ default: () => '/' }));
+vi.mock('@/hooks/useSession', () => ({
+  default: () => ({
+    user: {
+      id: 1,
+      name: 'Test User',
+      email: 'test@example.com',
+      is_admin: 0,
+      avatar: '',
+      scores: [],
+      answers: []
+    },
+    clear: vi.fn()
+  })
+}));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }) }));
+vi.mock('next-themes', () => ({ useTheme: () => ({ theme: 'light' }) }));
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => children,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => children,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div role="menu">{children}</div>
+  ),
+  DropdownMenuItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuLabel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuSeparator: () => <hr />
+}));
+
+import HamburgerProfileMenu from '.';
+
+afterEach(cleanup);
+
+describe('authenticated profile menu', () => {
+  it('separates the app profile from AuthNEI account management', () => {
+    render(<HamburgerProfileMenu />);
+
+    expect(screen.getByRole('link', { name: 'Perfil' })).toHaveAttribute('href', '/profile');
+    expect(screen.getByRole('link', { name: 'Gerir Conta' })).toHaveAttribute(
+      'href',
+      '/api/auth/profile'
+    );
+    expect(screen.getAllByRole('separator')).toHaveLength(2);
+  });
+});

--- a/src/components/navbar/HamburguerProfileMenu/index.tsx
+++ b/src/components/navbar/HamburguerProfileMenu/index.tsx
@@ -13,12 +13,13 @@ import {
 import useCallbackUrl from '@/hooks/useCallbackUrl';
 import useSession from '@/hooks/useSession';
 import { switchAuthNeiAccount } from '@/lib/client-auth-actions';
-import { LogIn, LogOut, RefreshCw, UserCog, UserPlus } from 'lucide-react';
+import { LogIn, LogOut, RefreshCw, User, UserCog, UserPlus } from 'lucide-react';
 import { signOut } from 'next-auth/react';
 import { useTheme } from 'next-themes';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import swal from 'sweetalert';
+import { APP_PROFILE_LINK, AUTHNEI_ACCOUNT_LINK } from '../profileLinks';
 
 const HamburgerProfileMenu: React.FC = () => {
   const pathname = useCallbackUrl();
@@ -127,9 +128,16 @@ const HamburgerProfileMenu: React.FC = () => {
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
         <DropdownMenuItem asChild>
-          <Link href="/api/auth/profile" className="cursor-pointer">
+          <Link href={APP_PROFILE_LINK.href} className="cursor-pointer">
+            <User className="size-4" />
+            <span>{APP_PROFILE_LINK.label}</span>
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <Link href={AUTHNEI_ACCOUNT_LINK.href} className="cursor-pointer">
             <UserCog className="size-4" />
-            <span>Gerir perfil</span>
+            <span>{AUTHNEI_ACCOUNT_LINK.label}</span>
           </Link>
         </DropdownMenuItem>
         <DropdownMenuItem onClick={handleSwitchAccount} className="cursor-pointer">

--- a/src/components/navbar/HamburguerProfileMenu/index.tsx
+++ b/src/components/navbar/HamburguerProfileMenu/index.tsx
@@ -135,10 +135,10 @@ const HamburgerProfileMenu: React.FC = () => {
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem asChild>
-          <Link href={AUTHNEI_ACCOUNT_LINK.href} className="cursor-pointer">
+          <a href={AUTHNEI_ACCOUNT_LINK.href} className="cursor-pointer">
             <UserCog className="size-4" />
             <span>{AUTHNEI_ACCOUNT_LINK.label}</span>
-          </Link>
+          </a>
         </DropdownMenuItem>
         <DropdownMenuItem onClick={handleSwitchAccount} className="cursor-pointer">
           <RefreshCw className="size-4" />

--- a/src/components/navbar/profileLinks.ts
+++ b/src/components/navbar/profileLinks.ts
@@ -1,0 +1,5 @@
+export const APP_PROFILE_LINK = { href: '/profile', label: 'Perfil' } as const;
+export const AUTHNEI_ACCOUNT_LINK = {
+  href: '/api/auth/profile',
+  label: 'Gerir Conta'
+} as const;

--- a/src/components/scoreboard/UserAvatar/index.test.tsx
+++ b/src/components/scoreboard/UserAvatar/index.test.tsx
@@ -1,0 +1,17 @@
+// @vitest-environment happy-dom
+/// <reference types="@testing-library/jest-dom" />
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import UserAvatar from '.';
+
+afterEach(cleanup);
+
+describe('user avatar', () => {
+  it('renders identity as read-only', () => {
+    render(<UserAvatar avatar="avatar-hash" />);
+
+    expect(screen.queryByRole('link')).toBeNull();
+    expect(screen.queryByText('Alterar')).toBeNull();
+  });
+});

--- a/src/components/scoreboard/UserAvatar/index.tsx
+++ b/src/components/scoreboard/UserAvatar/index.tsx
@@ -1,9 +1,4 @@
-'use client';
-
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { motion } from 'framer-motion';
-import { Camera } from 'lucide-react';
-import Link from 'next/link';
 
 interface UserAvatarProps {
   avatar?: string;
@@ -13,30 +8,10 @@ interface UserAvatarProps {
 
 const UserAvatar: React.FC<UserAvatarProps> = ({ avatar }) => {
   return (
-    <Link
-      href="https://en.gravatar.com/gravatars/new/computer"
-      target="_blank"
-      rel="noreferrer"
-      className="relative group"
-    >
-      <motion.div
-        whileHover={{ scale: 1.03 }}
-        transition={{ duration: 0.2 }}
-        className="relative"
-      >
-        <Avatar className="size-24 md:size-32 ring-4 ring-primary/20 group-hover:ring-primary/40 transition-all">
-          <AvatarImage
-            src={`https://gravatar.com/avatar/${avatar}?s=256&d=identicon`}
-            alt="Avatar"
-          />
-          <AvatarFallback className="text-2xl">?</AvatarFallback>
-        </Avatar>
-        <div className="absolute inset-0 rounded-full bg-primary/70 opacity-0 group-hover:opacity-100 transition-opacity flex flex-col items-center justify-center text-white text-xs md:text-sm font-semibold gap-1">
-          <Camera className="size-5 md:size-6" />
-          <span>Alterar</span>
-        </div>
-      </motion.div>
-    </Link>
+    <Avatar className="size-24 md:size-32 ring-4 ring-primary/20">
+      <AvatarImage src={`https://gravatar.com/avatar/${avatar}?s=256&d=identicon`} alt="Avatar" />
+      <AvatarFallback className="text-2xl">?</AvatarFallback>
+    </Avatar>
   );
 };
 


### PR DESCRIPTION
## Summary
- add separate Perfil and Gerir Conta destinations to authenticated desktop and mobile menus
- keep Antirecurso profile identity read-only and route account management through /api/auth/profile
- remove obsolete Gravatar editing affordance and cover navigation/read-only behavior

## Verification
- pnpm install --frozen-lockfile
- pnpm lint (3 existing warnings)
- pnpm typecheck
- pnpm test (49 passed)
- pnpm build
- pnpm audit --prod

No frontend/backend contract change is included; GET /user remains unchanged.

Closes #135